### PR TITLE
🔖(minor) prepare 0.1.0 distribution release

### DIFF
--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-api'
+      - 'v[0-9]+.[0-9]+.[0-9]+$'
 
 jobs:
   hub:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-app'
+      - 'v[0-9]+.[0-9]+.[0-9]+$'
 
 jobs:
   hub:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2024-03-05
+
+### Added
+
+- Add a custom API Docker image, based on `warren:api-core-0.1.0`, for the tdbp plugin indicator
+- Add a custom APP Docker image, based on `warren:app-0.1.0`, to serve the Warren-TdBP frontend application
+
+[unreleased]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.1.0...main
+[0.1.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/dd18c21...v0.1.0

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM fundocker/warren:api-core-main as base
+FROM fundocker/warren:api-core-0.1.0 as base
 
 # -- Builder --
 FROM base as builder

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM  fundocker/warren:app-main
+FROM  fundocker/warren:app-0.1.0
 
 # Privileged user
 USER root:root


### PR DESCRIPTION
Releases GitHub Actions were planned to be triggered on the tags `vX.X.X-app` and `vX.X.X-api`.
Having them triggered on a common "distribution" tag `vX.X.X` is easier to manage.

Changelog for the 0.1.0 release: 
- Add a custom API Docker image, based on `warren:api-core-0.1.0`, for the tdbp plugin indicator
- Add a custom APP Docker image, based on `warren:app-0.1.0`, to serve the Warren-TdBP frontend application