### PR TITLE
💄(frontend) implement slider to studentscomparison chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Rework frontend to connect to now stable API
+
 ## [0.1.0] - 2024-03-05
 
 ### Added

--- a/src/frontend/packages/tdbp/src/components/Radar/index.tsx
+++ b/src/frontend/packages/tdbp/src/components/Radar/index.tsx
@@ -14,6 +14,7 @@ import { RadarChartOption } from "../../types/chartOptions";
 const baseOption: RadarChartOption = {
   tooltip: {
     trigger: "item",
+    valueFormatter: (value) => value.toFixed(2),
     axisPointer: {
       // Use axis to trigger tooltip
       type: "shadow", // 'shadow' as default; can also be 'line' or 'shadow'

--- a/src/frontend/packages/tdbp/src/components/Radar/index.tsx
+++ b/src/frontend/packages/tdbp/src/components/Radar/index.tsx
@@ -12,6 +12,13 @@ import { isInEnum } from "../Activities/index";
 import { RadarChartOption } from "../../types/chartOptions";
 
 const baseOption: RadarChartOption = {
+  tooltip: {
+    trigger: "item",
+    axisPointer: {
+      // Use axis to trigger tooltip
+      type: "shadow", // 'shadow' as default; can also be 'line' or 'shadow'
+    },
+  },
   legend: {
     data: ["Moyenne cohorte", "Étudiant sélectionné"],
   },

--- a/src/frontend/packages/tdbp/src/components/StudentsComparison/index.tsx
+++ b/src/frontend/packages/tdbp/src/components/StudentsComparison/index.tsx
@@ -117,8 +117,8 @@ export const StudentsComparison = ({ course_id }: StudentsComparisonProps) => {
 
     const newOption = cloneDeep(baseOption);
 
-    let studentScores: Array<StudentScore> = Object.entries(data.scores).map(
-      ([username, scores]) => ({
+    const studentScores: Array<StudentScore> = Object.entries(data.scores)
+      .map(([username, scores]) => ({
         username,
         scoreActivity: sumScores(
           scores,
@@ -128,13 +128,13 @@ export const StudentsComparison = ({ course_id }: StudentsComparisonProps) => {
           scores,
           data.actions.map((action) => isInEnum(action.module_type, Resource)),
         ),
-      }),
-    );
-
-    studentScores = studentScores.sort(
-      (a, b) =>
-        a.scoreActivity + a.scoreResource - (b.scoreActivity + b.scoreResource),
-    );
+      }))
+      .sort(
+        (a, b) =>
+          a.scoreActivity +
+          a.scoreResource -
+          (b.scoreActivity + b.scoreResource),
+      );
 
     newOption.yAxis.data = studentScores.map((e) => e.username);
 

--- a/src/frontend/packages/tdbp/src/types/chartOptions.ts
+++ b/src/frontend/packages/tdbp/src/types/chartOptions.ts
@@ -40,6 +40,12 @@ export interface BarChartOption {
 }
 
 export interface RadarChartOption {
+  tooltip: {
+    trigger: string;
+    axisPointer: {
+      type: "shadow" | "line";
+    };
+  };
   legend: {
     data: string[];
   };

--- a/src/frontend/packages/tdbp/src/types/chartOptions.ts
+++ b/src/frontend/packages/tdbp/src/types/chartOptions.ts
@@ -67,6 +67,7 @@ export interface RadarChartOption {
     axisPointer: {
       type: "shadow" | "line";
     };
+    valueFormatter: (value: number) => string;
   };
   legend: {
     data: string[];

--- a/src/frontend/packages/tdbp/src/types/chartOptions.ts
+++ b/src/frontend/packages/tdbp/src/types/chartOptions.ts
@@ -5,6 +5,7 @@ export interface BarChartOption {
       type: "shadow" | "line";
     };
   };
+  animation?: boolean;
   legend: {
     data?: string[];
   };
@@ -13,6 +14,27 @@ export interface BarChartOption {
     right: string;
     bottom: string;
     containLabel: boolean;
+  };
+  dataZoom?: Array<{
+    type?: string;
+    yAxisIndex?: number;
+    zoomLock?: boolean;
+    filterMode?: string;
+    width?: number;
+    right?: number;
+    top?: number;
+    bottom?: number;
+    start?: number;
+    end?: number;
+    handleSize?: number;
+    showDetail?: boolean;
+    zoomOnMouseWheel?: false;
+    moveOnMouseMove?: true;
+    moveOnMouseWheel?: true;
+  }>;
+  emphasis?: {
+    focus: string;
+    blurScope: string;
   };
   xAxis: {
     type: string;


### PR DESCRIPTION
## Purpose

- StudentsComparison chart could not correctly render bars when handling a large volume of students.
- Radar chart lacked a hover tooltip to display student and cohort mean scores.

## Proposal

- [x] Add a data zoom slider to limit the display to a manageable number of students bars, while also allowing seamless scrolling for exploration.
- [x] Add radar chart hover tooltip

https://github.com/apui-avignon-university/warren-tdbp/assets/18288083/52c4100b-de24-4fb2-ba9b-3b5d22d5303f


