### PR TITLE
⚡️(project) reduce time to display

### DIFF
--- a/src/api/plugins/tdbp/warren_tdbp/indicators.py
+++ b/src/api/plugins/tdbp/warren_tdbp/indicators.py
@@ -141,8 +141,8 @@ class SlidingWindowIndicator(BaseIndicator, CacheMixin):
                 inplace=True,
             )
 
-        raw_statements["timestamp"] = raw_statements["timestamp"].apply(
-            pd.to_datetime, utc=True
+        raw_statements["timestamp"] = pd.to_datetime(
+            raw_statements["timestamp"], errors="raise", utc=True
         )
         raw_statements["date"] = raw_statements["timestamp"].dt.date
 

--- a/src/frontend/packages/tdbp/src/api/getScores.ts
+++ b/src/frontend/packages/tdbp/src/api/getScores.ts
@@ -38,7 +38,10 @@ type UseScoresReturn = {
   isFetching: boolean;
 };
 
-export const useScore = (queryParams: ScoresQueryParams): UseScoresReturn => {
+export const useScore = (
+  queryParams: ScoresQueryParams,
+  enabled?: boolean,
+): UseScoresReturn => {
   // Get the API client, set with the authorization headers and refresh mechanism
   const client = useTokenInterceptor(apiAxios);
 
@@ -46,6 +49,7 @@ export const useScore = (queryParams: ScoresQueryParams): UseScoresReturn => {
     queryKey: [DEFAULT_BASE_QUERY_KEY, queryParams],
     queryFn: () => getScore(client, queryParams),
     staleTime: Infinity,
+    enabled,
   });
 
   const { isFetching, data } = queryResult;

--- a/src/frontend/packages/tdbp/src/components/Radar/index.tsx
+++ b/src/frontend/packages/tdbp/src/components/Radar/index.tsx
@@ -43,12 +43,10 @@ interface RadarProps {
 export const Radar = ({ course_id }: RadarProps) => {
   const { until } = useTdbpFilters();
   const { slidingWindow } = useSlidingWindow({ course_id, until });
-
-  const { data } = useScore({
-    course_id,
-    until,
-    average: true,
-  });
+  const { data } = useScore(
+    { course_id, until, average: true },
+    !!slidingWindow,
+  );
 
   const [selectedStudent, setSelectedStudent] = useState<string>();
 

--- a/src/frontend/packages/tdbp/src/components/StudentsComparison/index.tsx
+++ b/src/frontend/packages/tdbp/src/components/StudentsComparison/index.tsx
@@ -4,7 +4,11 @@ import ReactECharts from "echarts-for-react";
 import cloneDeep from "lodash.clonedeep";
 import { Card } from "@openfun/warren-core";
 import { useIsFetching } from "@tanstack/react-query";
-import { Activity, Resource } from "../../api/getSlidingWindow";
+import {
+  Activity,
+  Resource,
+  useSlidingWindow,
+} from "../../api/getSlidingWindow";
 import { useTdbpFilters } from "../../hooks/useTdbpFilters";
 import { useScore } from "../../api/getScores";
 import { isInEnum } from "../Activities";
@@ -85,7 +89,11 @@ interface StudentScore {
  */
 export const StudentsComparison = ({ course_id }: StudentsComparisonProps) => {
   const { until } = useTdbpFilters();
-  const { data } = useScore({ course_id, until, average: true });
+  const { slidingWindow } = useSlidingWindow({ course_id, until });
+  const { data } = useScore(
+    { course_id, until, average: true },
+    !!slidingWindow,
+  );
 
   const sumScores = (scores: Array<number>, actionMask: Array<boolean>) => {
     const sum = scores


### PR DESCRIPTION
## Purpose

Displaying a dashboard can take a very long time, having some loading times close to +80seconds.

## Proposal

Find biggest bottlenecks and try to speed them up:
- ⚡️(indicators) improve performance of datetime conversion
- ⚡️(frontend) make score query dependent of sliding window query

We are now under the 50 seconds to display all charts, but it should greatly decrease once we can use the indicator caching again (see https://github.com/openfun/warren/pull/245), as we are recomputing the sliding window multiple times.

