### PR TITLE
⬆️(project) upgrade base warren images to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- Upgrade base Warren images to 0.2.0
 - Rework frontend to connect to now stable API
 
 ## [0.1.0] - 2024-03-05

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM fundocker/warren:api-core-0.1.0 as base
+FROM fundocker/warren:api-core-0.2.0 as base
 
 # -- Builder --
 FROM base as builder

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM  fundocker/warren:app-0.1.0
+FROM  fundocker/warren:app-0.2.0
 
 # Privileged user
 USER root:root


### PR DESCRIPTION
## Purpose

`warren:api-core-0.2.0` and `warren:app-0.2.0` are released.

## Proposal

Upgrading base images to these last revision.
