### PR TITLE
🔖(minor) prepare 0.2.0 distribution release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## [0.2.0] - 2024-05-23
 
 ### Changed
 
@@ -20,5 +22,6 @@ and this project adheres to
 - Add a custom API Docker image, based on `warren:api-core-0.1.0`, for the tdbp plugin indicator
 - Add a custom APP Docker image, based on `warren:app-0.1.0`, to serve the Warren-TdBP frontend application
 
-[unreleased]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.1.0...main
+[unreleased]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.2.0...main
+[0.2.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/dd18c21...v0.1.0

--- a/production/docker-compose.prod.yml
+++ b/production/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       - backend
   
   app:
-    image: apuiavignonuniversity/warren-tdbp:app-0.1.0
+    image: apuiavignonuniversity/warren-tdbp:app-0.2.0
     env_file:
       - env.d/app.env
     ports:
@@ -49,7 +49,7 @@ services:
       - backend
 
   api:
-    image: apuiavignonuniversity/warren-tdbp:api-0.1.0
+    image: apuiavignonuniversity/warren-tdbp:api-0.2.0
     env_file:
       - env.d/api.env
     ports:

--- a/src/api/plugins/tdbp/warren_tdbp/__init__.py
+++ b/src/api/plugins/tdbp/warren_tdbp/__init__.py
@@ -1,3 +1,3 @@
 """Warren TdBP plugin main package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
### Changed

- Upgrade base Warren images to 0.2.0
- Rework frontend to connect to now stable API
