### PR TITLE
💚(project) trigger release actions on tag

### DIFF
--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -2,8 +2,6 @@ name: Publish API image to Hub
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+$'
 

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -2,8 +2,6 @@ name: Publish APP image to Hub
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+$'
 


### PR DESCRIPTION
## Purpose

Release actions that publish docker images to Dockerhub are not triggered.

## Proposal

Fixing the issue so these actions are triggered when a tag is pushed.
