### PR TITLE
💚(project) fix trigger of release actions on tag and on main

### DIFF
--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -2,8 +2,10 @@ name: Publish API image to Hub
 
 on:
   push:
+    branches: 
+      - main
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+$'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   hub:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -2,8 +2,10 @@ name: Publish APP image to Hub
 
 on:
   push:
+    branches: 
+      - main
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+$'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   hub:


### PR DESCRIPTION
## Purpose

Release actions that publish docker images to Dockerhub are still not triggered.
Github Actions filter pattern does not support regex characters such as `$`.

## Proposal

Removing this character in the pattern, and reverting back trigger on main branch push to release intermediate images.
