### PR TITLE
🔧(project) set absolute disk watermark limits for elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,10 @@ services:
       bootstrap.memory_lock: true
       discovery.type: single-node
       xpack.security.enabled: "false"
+      cluster.routing.allocation.disk.watermark.low: "2gb"
+      cluster.routing.allocation.disk.watermark.high: "1gb"
+      cluster.routing.allocation.disk.watermark.flood_stage: "500mb"
+      cluster.info.update.interval: "1m"
     ports:
       - "9200:9200"
     mem_limit: 2g


### PR DESCRIPTION
## Purpose

By default, Elasticsearch sets disk watermark values as percentages of
available disk space. For developers working locally, this can results in
insufficient disk space to run the Elasticsearch container.

## Proposal

To address this, setting the low and high watermark limits to absolute values.
