### PR TITLE
🔒️(api) restrict student visibility of cohort information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- API: Restrict student access to cohort information
 - Upgrade base Warren images to 0.3.0
 - Secure API endpoints with LTI token
 

--- a/src/api/plugins/tdbp/warren_tdbp/models.py
+++ b/src/api/plugins/tdbp/warren_tdbp/models.py
@@ -64,15 +64,16 @@ class Action(BaseModel):
     module_type: Union[Ressources, Activities]
     activation_date: date
     activation_rate: float
-    activation_students: List[str]
+    activation_students: Optional[List[str]] = None
+    is_activator_student: Optional[bool] = None
 
 
 class SlidingWindow(BaseModel):
     """Model for computed sliding window indicator."""
 
     window: Window
-    active_actions: Optional[List[Action]]
-    dynamic_cohort: Optional[List[str]]
+    active_actions: Optional[List[Action]] = None
+    dynamic_cohort: Optional[Union[List[str], int]]
 
 
 class Scores(BaseModel):

--- a/src/api/plugins/tdbp/warren_tdbp/utils.py
+++ b/src/api/plugins/tdbp/warren_tdbp/utils.py
@@ -1,6 +1,7 @@
 """Utils for TdbP."""
 
 import logging
+from typing import List
 
 from pydantic import ValidationError
 
@@ -10,12 +11,29 @@ logger = logging.getLogger(__name__)
 def dataframe_to_pydantic(model_class, dataframe):
     """Convert a dataframe to a list of Pydantic model instances."""
     columns = model_class.__annotations__.keys()
+    existing_columns = [col for col in columns if col in dataframe.columns]
 
     model = []
     for _, row in dataframe.iterrows():
         try:
-            model.append(model_class(**row[columns]))
+            row_dict = {col: row[col] for col in existing_columns}
+            # Create an instance of the model class
+            model_instance = model_class(**row_dict)
+            model.append(model_instance)
         except ValidationError as e:
             logger.warning("Could not convert dataframe to pydantic: %s", e)
             continue
     return model
+
+
+def is_instructor(roles: List[str]):
+    """Determine if any of the provided roles match an instructor position.
+
+    Args:
+        roles (List[str]): A list of roles.
+
+    Returns:
+        bool: True if any role in the list is `instructor`, `teacher`, or
+        `staff`, otherwise False.
+    """
+    return any(role in ["instructor", "teacher", "staff"] for role in roles)


### PR DESCRIPTION
## Purpose

In sliding window and cohort endpoints, students could still see student_ids of
the whole course cohort. 

# Proposal

It has been restricted either to their data only or aggregated data.

- Return only student activity in `/cohort`
- Remove `activation_students` in `/window` and set a flag to `True` or `False` for
  students
- Remove `dynamic_cohort` in `window` for students

