### PR TITLE
⬆️(project) upgrade base warren images to 0.4.0 and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-07-16
+
 ### Changed
 
 - Upgrade base Warren images to 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade base Warren images to 0.4.0
+
 ## [0.3.1] - 2024-07-03
 
 ### Changed

--- a/production/docker-compose.prod.yml
+++ b/production/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       - backend
   
   app:
-    image: apuiavignonuniversity/warren-tdbp:app-v0.3.1
+    image: apuiavignonuniversity/warren-tdbp:app-v0.4.0
     env_file:
       - env.d/app.env
     ports:
@@ -49,7 +49,7 @@ services:
       - backend
 
   api:
-    image: apuiavignonuniversity/warren-tdbp:api-v0.3.1
+    image: apuiavignonuniversity/warren-tdbp:api-v0.4.0
     env_file:
       - env.d/api.env
     ports:
@@ -82,7 +82,7 @@ services:
       - backend
 
   indexer-cronjob:
-    image: apuiavignonuniversity/warren-tdbp:api-v0.3.1
+    image: apuiavignonuniversity/warren-tdbp:api-v0.4.0
     env_file:
       - env.d/api.env
     environment:

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,8 +1,8 @@
 # -- Base image --
-FROM fundocker/warren:api-core-0.3.2 as base
+FROM fundocker/warren:api-core-0.4.0 AS base
 
 # -- Builder --
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /build
 
@@ -14,7 +14,7 @@ COPY . /build/
 RUN pip install ./plugins/tdbp
 
 # -- Core --
-FROM base as core
+FROM base AS core
 
 COPY --from=builder /usr/local /usr/local
 
@@ -30,7 +30,7 @@ RUN  apt-get update && \
      rm -rf /var/lib/apt/lists/*
 
 # -- Development --
-FROM core as development
+FROM core AS development
 
 # Should be a priviledged user
 USER root:root
@@ -47,7 +47,7 @@ RUN pip install -e plugins/tdbp[dev]
 USER ${DOCKER_USER:-1000}
 
 # -- Production --
-FROM core as production
+FROM core AS production
 
 # Un-privileged user running the application
 USER ${DOCKER_USER:-1000}

--- a/src/api/plugins/tdbp/warren_tdbp/__init__.py
+++ b/src/api/plugins/tdbp/warren_tdbp/__init__.py
@@ -1,3 +1,3 @@
 """Warren TdBP plugin main package."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM  fundocker/warren:app-0.3.2
+FROM  fundocker/warren:app-0.4.0
 
 # Privileged user
 USER root:root


### PR DESCRIPTION
## Purpose

- `warren:api-core-0.4.0` and `warren:app-0.4.0` are released. Upgrading base images to these last revision.
- Prepare 0.4.0 distribution released
