### PR TITLE
⬆️(project) upgrade base warren images to 0.5.0 and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-07-16
+
 - Upgrade base Warren images to 0.5.0
 
 ## [0.4.0] - 2024-07-16
@@ -44,7 +46,9 @@ and this project adheres to
 - Add a custom API Docker image, based on `warren:api-core-0.1.0`, for the tdbp plugin indicator
 - Add a custom APP Docker image, based on `warren:app-0.1.0`, to serve the Warren-TdBP frontend application
 
-[unreleased]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.3.1...main
+[unreleased]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.5.0...main
+[0.5.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/apui-avignon-university/warren-tdbp/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Upgrade base Warren images to 0.5.0
+
 ## [0.4.0] - 2024-07-16
 
 ### Changed

--- a/production/docker-compose.prod.yml
+++ b/production/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       - backend
   
   app:
-    image: apuiavignonuniversity/warren-tdbp:app-v0.4.0
+    image: apuiavignonuniversity/warren-tdbp:app-v0.5.0
     env_file:
       - env.d/app.env
     ports:
@@ -49,7 +49,7 @@ services:
       - backend
 
   api:
-    image: apuiavignonuniversity/warren-tdbp:api-v0.4.0
+    image: apuiavignonuniversity/warren-tdbp:api-v0.5.0
     env_file:
       - env.d/api.env
     ports:
@@ -82,7 +82,7 @@ services:
       - backend
 
   indexer-cronjob:
-    image: apuiavignonuniversity/warren-tdbp:api-v0.4.0
+    image: apuiavignonuniversity/warren-tdbp:api-v0.5.0
     env_file:
       - env.d/api.env
     environment:

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM fundocker/warren:api-core-0.4.0 AS base
+FROM fundocker/warren:api-core-0.5.0 AS base
 
 # -- Builder --
 FROM base AS builder

--- a/src/api/plugins/tdbp/warren_tdbp/__init__.py
+++ b/src/api/plugins/tdbp/warren_tdbp/__init__.py
@@ -1,3 +1,3 @@
 """Warren TdBP plugin main package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM  fundocker/warren:app-0.4.0
+FROM  fundocker/warren:app-0.5.0
 
 # Privileged user
 USER root:root


### PR DESCRIPTION
## Purpose

- `warren:api-core-0.5.0` and `warren:app-0.5.0` are released. Upgrading base images to these last revision.
- Prepare 0.5.0 distribution released
